### PR TITLE
ControlsFX version bump

### DIFF
--- a/Library_FX/build.gradle
+++ b/Library_FX/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile 'com.miglayout:miglayout-javafx:5.0'
     compile 'org.jfxtras:jfxtras-controls:8.0-r4'
     compile 'org.jfxtras:jfxtras-labs:8.0-r4'
-    compile 'org.controlsfx:controlsfx:8.40.10'
+    compile 'org.controlsfx:controlsfx:8.40.11'
     compile 'org.controlsfx:openjfx-dialogs:1.0.3'
     compile project(':Library')
     testCompile testDependencies //includes JUnit etc.


### PR DESCRIPTION
ControlsFX 8.40.10 has a bug in its version checker where it erroneously decides JDK8u102 is older than JDK8u40 and refuses to launch.  ControlsFX 8.40.11 fixes this, allowing Anathema to run.
